### PR TITLE
Add Dependabot for tutorial client dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    target-branch: master
+    schedule:
+      interval: weekly
+      day: monday
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: master
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
Configure Dependabot to open weekly PRs for Hazelcast client example dependencies (Go modules, Maven, npm, Python) and GitHub Actions where applicable.

Root `package.json` Antora playbook dependencies are intentionally excluded.